### PR TITLE
44/cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+## [4.1.0] - 2023-09-16
+
+- Integrate `cargo metadata` to resolve target directory for docs, fallback to legacy on failure
+
 ## [4.0.1] - 2023-09-10
 
 - Handle legacy rustdoc vars `div` + `id` or newly introduced vars `meta` + `name`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "color": "#0e95b7",
     "theme": "dark"
   },
-  "version": "4.0.1",
+  "version": "4.1.0",
   "engines": {
     "vscode": "^1.45.0"
   },

--- a/src/cargoInterop/index.ts
+++ b/src/cargoInterop/index.ts
@@ -1,0 +1,1 @@
+export { cargoSafeMetadata } from './metadata';

--- a/src/cargoInterop/metadata.ts
+++ b/src/cargoInterop/metadata.ts
@@ -1,0 +1,104 @@
+import { exec } from 'child_process';
+import { Observable, from, mergeMap } from 'rxjs';
+import { Option, some, none } from 'fp-ts/Option';
+
+const versionTest = /cargo\s(\d+\.\d+\.\d+).*/i;
+
+const cargoExists = (cwd?: string): Observable<boolean> => {
+  return new Observable((subscriber) => {
+    exec('cargo --version', { cwd, windowsHide: true }, (error, stdout, stderr) => {
+      if (error || stderr) {
+        subscriber.next(false);
+      } else if (stdout) {
+        subscriber.next(versionTest.test(stdout));
+      }
+      subscriber.complete();
+    });
+  });
+};
+
+const cargoMetadata = (cwd?: string): Observable<Option<Metadata>> => {
+  return new Observable((subscriber) => {
+    exec('cargo metadata --no-deps --format-version 1 -q', { cwd, windowsHide: true }, (error, stdout, stderr) => {
+      if (error || stderr) {
+        subscriber.next(none);
+      } else if (stdout) {
+        try {
+          const metadata: Metadata = JSON.parse(stdout);
+          if (metadata) {
+            subscriber.next(some(metadata));
+          } else {
+            subscriber.next(none);
+          }
+        } catch {
+          subscriber.next(none);
+        }
+      }
+
+      subscriber.complete();
+    });
+  });
+};
+
+export const cargoSafeMetadata = (cwd?: string): Observable<Option<Metadata>> => {
+  return cargoExists().pipe(
+    mergeMap((exists) => {
+      if (exists) {
+        return cargoMetadata(cwd);
+      } else {
+        return from([none]);
+      }
+    })
+  );
+};
+
+type Metadata = {
+  packages: Package[];
+  workspace_members: string[];
+  workspace_default_members: string[];
+  resolve: any;
+  target_directory: string;
+  version: number;
+  workspace_root: string;
+};
+
+type Package = {
+  name: string;
+  version: string;
+  id: string;
+  license: string;
+  license_file: string;
+  description: string;
+  source: string | null;
+  dependencies: Dependency[];
+  targets: Target[];
+  features: Features;
+  manifest_path: string;
+};
+
+export interface Dependency {
+  name: string;
+  source: string;
+  req: string;
+  kind: 'dev' | 'build' | null;
+  rename: string | null;
+  optional: boolean;
+  uses_default_features: boolean;
+  features: string[];
+  target: string | null;
+  path?: string;
+  registry: string | null;
+}
+
+export interface Target {
+  kind: string[];
+  crate_types: string[];
+  name: string;
+  src_path: string;
+  edition: string;
+  doc: boolean;
+  doctest: boolean;
+  test: boolean;
+}
+
+export interface Features {}


### PR DESCRIPTION
- Integrate `cargo metadata` to generate docs directories + names
- Fallback to legacy search strategy if `cargo metadata` strategy fails
- Run `prettier:write`