### PR TITLE
#43 handle meta or div for rustdoc-vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage/
 node_modules
 out
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+## [4.0.1] - 2023-09-10
+
+- Handle legacy rustdoc vars `div` + `id` or newly introduced vars `meta` + `name`
+- Remove unecessary console logs
+- Prettier updates
+
 ## [4.0.0] - 2023-07-09
 
 - Fix storage load order issue, allowing VSCode stored settings to intercept storage calls

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "color": "#0e95b7",
     "theme": "dark"
   },
-  "version": "4.0.0",
+  "version": "4.0.1",
   "engines": {
     "vscode": "^1.45.0"
   },

--- a/src/client/clickHandlers.ts
+++ b/src/client/clickHandlers.ts
@@ -3,16 +3,15 @@ import { CommandKey } from './command';
 const bubbleTargets = ['SUMMARY'];
 
 export const eventShouldBubble = (element: Element) => {
-  const inSettings = !!element.closest(".settings");
+  const inSettings = !!element.closest('.settings');
   return inSettings || bubbleTargets.includes(element.tagName);
 };
 
 // settings-menu button opens modal, no need to load a new file from this button
 export const eventHandled = (element: Element) => {
-  const inSettings = element.id === 'settings-menu' || !!element.closest("#settings-menu");
+  const inSettings = element.id === 'settings-menu' || !!element.closest('#settings-menu');
   return inSettings;
 };
-
 
 export const navigateClickHandler = (element: HTMLElement) => {
   const el = getElementToHandle(element);
@@ -24,7 +23,7 @@ export const navigateClickHandler = (element: HTMLElement) => {
         commandType: CommandKey.navigateAnchor,
         payload: {
           id,
-          path: href
+          path: href,
         },
       };
     } else if (href === '') {

--- a/src/client/clientHandler.ts
+++ b/src/client/clientHandler.ts
@@ -16,7 +16,6 @@ const vscode = acquireVsCodeApi();
       return;
     }
 
-    
     e.preventDefault();
     e.stopPropagation();
     if (eventHandled(e.target as Element)) {
@@ -52,7 +51,7 @@ const vscode = acquireVsCodeApi();
     if (stateEl) {
       const data = stateEl.getAttribute('data-state') || '{}';
       vscode.setState(JSON.parse(data));
-      const event = new PageTransitionEvent("pageshow", { persisted: true });
+      const event = new PageTransitionEvent('pageshow', { persisted: true });
       window.dispatchEvent(event);
     }
     document.removeEventListener('DOMContentLoaded', contentLoaded);

--- a/src/client/cookieShim.ts
+++ b/src/client/cookieShim.ts
@@ -8,24 +8,23 @@ export const initCookieShim: (arg: any) => WindowExtensions = (vscode: any) => {
   Object.defineProperty(window, 'localStorage', {
     value: {
       getItem: (name: string) => {
-        console.log('getItem name', name);
         const state = vscode.getState();
-        return (state && state[name]);
+        return state && state[name];
       },
       setItem: (name: string, value: string) => {
         const state = vscode.getState();
-        const newState = {...state, [name]: value };
-        console.log(newState);
+        const newState = { ...state, [name]: value };
         vscode.setState(newState);
         vscode.postMessage({
           commandType: CommandKey.setState,
           payload: state,
         });
-      }},
+      },
+    },
     writable: true,
   });
 
   return Object.assign(window, {
     usableLocalStorage: () => true,
-  })
+  });
 };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -24,7 +24,7 @@ export const getConfiguration = async (extensionPath: string): Promise<Option<Co
   const workspaces = vscode.workspace.workspaceFolders;
   const rustShareDocPath = pipe(
     fromNullable(vscode.workspace.getConfiguration().get<string | undefined>('rustDocViewer.rustShareDocPath')),
-    map((docPath) => docPath[0] === '~' ? docPath.replace('~', os.homedir()) : docPath),
+    map((docPath) => (docPath[0] === '~' ? docPath.replace('~', os.homedir()) : docPath)),
     map((docPath) => join(docPath, 'rust', 'html'))
   );
   if (workspaces && workspaces.length > 0) {
@@ -109,7 +109,6 @@ const getDocsInfo = async (base: vscode.WorkspaceFolder): Promise<Option<{ names
             }
           } catch (e: any) {
             showError(`toml parse error in ${path}, error: ${e.message}`);
-            console.log('toml parse error in ', path, 'err:', e);
           }
         } else {
           acc.then((data) => {

--- a/src/doc-listener/listener.d.ts
+++ b/src/doc-listener/listener.d.ts
@@ -1,5 +1,5 @@
-import { Observable } from "rxjs";
+import { Observable } from 'rxjs';
 
 type ListenerOpts<T> = {
-  slice: Observable<T>
+  slice: Observable<T>;
 };

--- a/src/doc-listener/postMessage.ts
+++ b/src/doc-listener/postMessage.ts
@@ -80,10 +80,7 @@ export const postMessageListener = ({ slice, view, workspaceState }: PostMessage
               ...currState,
               ...payload,
             };
-            workspaceState.update(
-              'rustDocViewer',
-              JSON.stringify(newState)
-            );
+            workspaceState.update('rustDocViewer', JSON.stringify(newState));
           }
           break;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,6 @@ import { errorListener } from './doc-listener/error';
 import { pipe } from 'fp-ts/lib/function';
 
 export function activate(context: vscode.ExtensionContext) {
-  console.log('"rust-doc-viewer" is now active');
   let viewRef: Option<vscode.WebviewPanel> = none;
   const disposable = vscode.commands.registerCommand('extension.rustDocViewer', async () => {
     const subscriptions = errorListener({ slice: slice([StateKey.errors]) });
@@ -20,9 +19,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (isNone(viewRef)) {
       const webViewOptions = {
         enableScripts: true,
-        localResourceRoots: [
-          vscode.Uri.file(context.extensionPath),
-        ] as vscode.Uri[],
+        localResourceRoots: [vscode.Uri.file(context.extensionPath)] as vscode.Uri[],
       };
       pipe(
         initConfig,

--- a/src/test/jest.e2e.config.js
+++ b/src/test/jest.e2e.config.js
@@ -3,7 +3,7 @@
  * https://jestjs.io/docs/configuration
  */
 
- module.exports = {
+module.exports = {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 
@@ -23,16 +23,13 @@
   // collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
-  coverageDirectory: "coverage",
+  coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
-  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    ".*\\/helpers\\/.*",
-  ],
+  coveragePathIgnorePatterns: ['/node_modules/', '.*\\/helpers\\/.*'],
 
   // Indicates which provider should be used to instrument code for coverage
-  coverageProvider: "v8",
+  coverageProvider: 'v8',
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [
@@ -149,7 +146,7 @@
   // The glob patterns Jest uses to detect test files
   testMatch: [
     // "**/tests/**/*.[jt]s?(x)",
-    "**/tests/**/?(*.)+e2e.[tj]s?(x)"
+    '**/tests/**/?(*.)+e2e.[tj]s?(x)',
   ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,7 +11,7 @@ export const subscriptionToDisposable = (sub: Subscription) => {
 
 const rustLangRegex = /.*\.rust-lang\.org.*/;
 export const isExternal = (path: string) => {
-  if (path.includes("vscode")) {
+  if (path.includes('vscode')) {
     return false;
   }
   const uri = Uri.parse(path);


### PR DESCRIPTION
- Handle `meta` tag containing rust doc vars, on top of the existing `div` versions.  This changes depending on `cargo` version
- Run `prettier:write`