### PR TITLE
#48 add extraEnv configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+## [4.2.0] - 2023-12-01
+
+- Add `extraEnv` VSCode setting, set before `cargo` commands are invoked
+
 ## [4.1.0] - 2023-09-16
 
 - Integrate `cargo metadata` to resolve target directory for docs, fallback to legacy on failure

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Open your rust docs and view them in another tab in VS Code
 
 ![Rust Doc Viewer Demo](images/rust-doc-viewer-demo.gif)
 
+### Additional configuration
+
+- `rustDocViewer.extraEnv`
+  - Set additional evironment variables that will be set before invoking `cargo` commands (used to get project docs location)
+  - Will merge with existing set of environment variables, overwriting overlapping variables
+  - A single object of key value pair(s)
+
 ## Known Issues
 
     1.) No easy navigation

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "color": "#0e95b7",
     "theme": "dark"
   },
-  "version": "4.1.0",
+  "version": "4.2.0",
   "engines": {
     "vscode": "^1.45.0"
   },
@@ -32,6 +32,19 @@
     "configuration": {
       "title": "Rust doc viewer",
       "properties": {
+        "rustDocViewer.extraEnv": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "description": "Variables in form of { \"key\": \"value\"}"
+            }
+          ],
+          "default": null,
+          "markdownDescription": "Set additional env variables for `cargo` calls. For example, custom PATH to include custom `cargo` implementation."
+        },
         "rustDocViewer.rustShareDocPath": {
           "type": "string",
           "markdownDescription": "Root path to docs (std/core) - installed by rustup, or otherwise built. Example: `~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/share/doc`"


### PR DESCRIPTION
- Add extraEnv configuration
- Compose process.env, and overwriting any overlap from extraEnv before invoking `cargo` commands